### PR TITLE
Validate ds file content

### DIFF
--- a/lib/openscap_parser/ds.rb
+++ b/lib/openscap_parser/ds.rb
@@ -13,6 +13,12 @@ module OpenscapParser
       @profiles ||= profile_nodes
     end
 
+    def valid?
+      return true if @report_xml.root.name == 'data-stream-collection' && namespaces.keys.include?('xmlns:ds')
+      return true if @report_xml.root.name == 'Tailoring' && namespaces.keys.include?('xmlns:xccdf')
+      false
+    end
+
     private
 
     def profile_nodes

--- a/lib/openscap_parser/xml_file.rb
+++ b/lib/openscap_parser/xml_file.rb
@@ -3,9 +3,12 @@ require 'nokogiri'
 
 module OpenscapParser
   module XmlFile
+    attr_reader :namespaces
+
     def report_xml(report_contents = '')
       @report_xml ||= ::Nokogiri::XML.parse(
         report_contents, nil, nil, Nokogiri::XML::ParseOptions.new.norecover)
+      @namespaces = @report_xml.namespaces.clone
       @report_xml.remove_namespaces!
     end
   end

--- a/test/ds_test.rb
+++ b/test/ds_test.rb
@@ -33,6 +33,30 @@ class DsTest < MiniTest::Test
     end
   end
 
+  context 'format validations' do
+    should 'remember the namespaces after removing them' do
+      refute_empty(create_parser('ssg-rhel7-ds.xml').namespaces)
+    end
+
+    should 'recognize scap content as valid' do
+      assert(create_parser('ssg-rhel7-ds.xml').valid?)
+    end
+
+    should 'recognize tailoring file as valid' do
+      assert(create_parser('ssg-rhel7-ds-tailoring.xml').valid?)
+    end
+
+    should 'not recognize random file as valid' do
+      assert_raises Nokogiri::XML::SyntaxError do
+        create_parser('invalid_report.xml')
+      end
+    end
+
+    should 'not recognize xccdf report as valid ds file' do
+      refute(create_parser('rhel-xccdf-report.xml').valid?)
+    end
+  end
+
   def create_parser(file)
     scap_content = file_fixture(file).read
     ::OpenscapParser::Ds.new(scap_content)


### PR DESCRIPTION
Makes a basic check to see
if file format corresponds
to tailoring file or scap
content.

File namespaces are kept
in a separate instance variable
so that they are available
even after they are removed
from the xml file.