### PR TITLE
Add a test for ospp42 in rhel7 SSG

### DIFF
--- a/test/openscap_parser/profiles_test.rb
+++ b/test/openscap_parser/profiles_test.rb
@@ -3,26 +3,45 @@
 require 'test_helper'
 
 class ProfilesTest < Minitest::Test
-  def test_result
-    OpenStruct.new(id: ['xccdf_org.ssgproject.content_profile_standard'])
-  end
+  describe 'profiles are parsed from' do
+    include OpenscapParser::Profiles
+    include OpenscapParser::XMLReport
 
-  def report_description
-    'description'
-  end
+    def report_description
+      'description'
+    end
 
-  include OpenscapParser::Profiles
-  include OpenscapParser::XMLReport
+    def setup
+      @profiles = nil
+    end
 
-  def setup
-    report_xml(file_fixture('xccdf_report.xml').read)
-  end
+    test 'standard fedora' do
+      def test_result_node
+        OpenStruct.new(id: ['xccdf_org.ssgproject.content_profile_standard'])
+      end
 
-  test 'profiles' do
-    expected = {
-      'xccdf_org.ssgproject.content_profile_standard' => \
-      'Standard System Security Profile for Fedora'
-    }
-    assert_equal expected, profiles
+      report_xml(file_fixture('xccdf_report.xml').read)
+
+      expected = {
+        'xccdf_org.ssgproject.content_profile_standard' => \
+        'Standard System Security Profile for Fedora'
+      }
+      assert_equal expected, profiles
+    end
+
+    test 'ospp42 rhel' do
+      def test_result_node
+        OpenStruct.new(id: ['xccdf_org.open-scap_testresult_xccdf_org.'\
+                            'ssgproject.content_profile_ospp42'])
+      end
+
+      report_xml(file_fixture('rhel-xccdf-report.xml').read)
+
+      expected = {
+        'xccdf_org.ssgproject.content_profile_ospp42' => 'OSPP - Protection '\
+        'Profile for General Purpose Operating Systems v. 4.2'
+      }
+      assert_equal expected, profiles
+    end
   end
 end


### PR DESCRIPTION
Towards https://projects.engineering.redhat.com/browse/RHICOMPL-329. It appears the bug isn't in the openscap_parser, but this test is still valid.

Signed-off-by: Andrew Kofink <akofink@redhat.com>