### PR TITLE
Update datastream file fixtures

### DIFF
--- a/test/datastream_test.rb
+++ b/test/datastream_test.rb
@@ -5,20 +5,21 @@ class DatastreamTest < MiniTest::Test
   context 'scap content' do
     should 'be able to parse profiles' do
       parser = create_parser('ssg-rhel7-ds.xml')
-      profile_titles = [
-        "United States Government Configuration Baseline",
-        "Standard System Security Profile for Red Hat Enterprise Linux 7",
-        "Criminal Justice Information Services (CJIS) Security Policy",
-        "C2S for Red Hat Enterprise Linux 7",
-        "Health Insurance Portability and Accountability Act (HIPAA)",
-        "Unclassified Information in Non-federal Information Systems and Organizations (NIST 800-171)",
-        "DISA STIG for Red Hat Enterprise Linux 7",
-        "OSPP - Protection Profile for General Purpose Operating Systems v. 4.2",
-        "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7",
-        "Red Hat Corporate Profile for Certified Cloud Providers (RH CCP)",
-        "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7"
+      profile_ref_ids = [
+        "xccdf_org.ssgproject.content_profile_standard",
+        "xccdf_org.ssgproject.content_profile_nist-800-171-cui",
+        "xccdf_org.ssgproject.content_profile_rht-ccp",
+        "xccdf_org.ssgproject.content_profile_C2S",
+        "xccdf_org.ssgproject.content_profile_cjis",
+        "xccdf_org.ssgproject.content_profile_hipaa",
+        "xccdf_org.ssgproject.content_profile_ospp",
+        "xccdf_org.ssgproject.content_profile_ospp42",
+        "xccdf_org.ssgproject.content_profile_pci-dss",
+        "xccdf_org.ssgproject.content_profile_stig-rhel7-disa",
+        "xccdf_org.ssgproject.content_profile_rhelh-vpp",
+        "xccdf_org.ssgproject.content_profile_pci-dss_centric"
       ]
-      assert_equal(profile_titles, parser.profiles.map(&:title))
+      assert_equal(profile_ref_ids, parser.profiles.map { |profile| profile.id })
     end
   end
 


### PR DESCRIPTION
I'm expecting tests to fail here. @xprazak2 you wrote some of the [failing validations](https://github.com/dLobatog/openscap_parser/blob/master/lib/openscap_parser/ds.rb#L17) - I wonder if you based the namespace requirement on the SCAP spec or just from an example datastream file? These three datastreams were downloaded from the ComplianceAsCode repo's latest release: https://github.com/ComplianceAsCode/content/releases/download/v0.1.46/scap-security-guide-0.1.46.zip

None of the three are 'valid' as written:

```rb
[1] pry(#<DsTest>)> create_parser('ssg-rhel7-ds.xml').valid?
=> false
[2] pry(#<DsTest>)> create_parser('ssg-rhel6-ds.xml').valid?
=> false
[3] pry(#<DsTest>)> create_parser('ssg-rhel8-ds.xml').valid?
=> false
```

Signed-off-by: Andrew Kofink <akofink@redhat.com>