### PR TITLE
Generalize scap parsing

### DIFF
--- a/lib/openscap_parser.rb
+++ b/lib/openscap_parser.rb
@@ -20,7 +20,7 @@ module OpenscapParser
     include OpenscapParser::RuleResults
 
     def initialize(report)
-      report_xml(report)
+      parsed_xml(report)
     end
 
     def score

--- a/lib/openscap_parser.rb
+++ b/lib/openscap_parser.rb
@@ -18,21 +18,10 @@ module OpenscapParser
     include OpenscapParser::Profiles
     include OpenscapParser::Rules
     include OpenscapParser::RuleResults
+    include OpenscapParser::TestResult
 
     def initialize(report)
       parsed_xml(report)
-    end
-
-    def score
-      test_result_node.search('score').text.to_f
-    end
-
-    def start_time
-      @start_time ||= DateTime.parse(test_result_node['start-time'])
-    end
-
-    def end_time
-      @end_time ||= DateTime.parse(test_result_node['end-time'])
     end
   end
 end

--- a/lib/openscap_parser/ds.rb
+++ b/lib/openscap_parser/ds.rb
@@ -6,7 +6,7 @@ module OpenscapParser
     include OpenscapParser::XmlFile
 
     def initialize(report)
-      report_xml report
+      parsed_xml report
     end
 
     def profiles
@@ -14,15 +14,15 @@ module OpenscapParser
     end
 
     def valid?
-      return true if @report_xml.root.name == 'data-stream-collection' && namespaces.keys.include?('xmlns:ds')
-      return true if @report_xml.root.name == 'Tailoring' && namespaces.keys.include?('xmlns:xccdf')
+      return true if @parsed_xml.root.name == 'data-stream-collection' && namespaces.keys.include?('xmlns:ds')
+      return true if @parsed_xml.root.name == 'Tailoring' && namespaces.keys.include?('xmlns:xccdf')
       false
     end
 
     private
 
     def profile_nodes
-      @report_xml.xpath(".//Profile").map do |node|
+      @parsed_xml.xpath(".//Profile").map do |node|
         id_node = node.attribute('id')
         id = id_node.value if id_node
         title_node = node.at_xpath('./title')

--- a/lib/openscap_parser/profile.rb
+++ b/lib/openscap_parser/profile.rb
@@ -1,6 +1,22 @@
 module OpenscapParser
   class Profile
-    attr_acessor :id, :title, :description
+    def initialize(profile_xml: nil)
+      @profile_xml = profile_xml
+    end
+
+    def id
+      @id ||= @profile_xml['id']
+    end
+
+    def title
+      @title ||= @profile_xml.at_css('title') &&
+        @profile_xml.at_css('title').text
+    end
+
+    def description
+      @description ||= @profile_xml.at_css('description') &&
+        @profile_xml.at_css('description').text
+    end
 
     def to_h
       { :id => id, :title => title, :description => description }

--- a/lib/openscap_parser/profiles.rb
+++ b/lib/openscap_parser/profiles.rb
@@ -1,25 +1,21 @@
 # frozen_string_literal: true
-require 'openscap_parser/test_result'
 
 module OpenscapParser
   # Methods related to saving profiles and finding which hosts
   # they belong to
   module Profiles
-    include TestResult
-
     def self.included(base)
       base.class_eval do
         def profiles
-          @profiles ||= {
-            profile_node['id'] => profile_node.at_css('title').text
-          }
+          @profiles ||= profile_nodes.inject({}) do |profiles, profile_node|
+            profiles[profile_node['id']] = profile_node.at_css('title').text
+
+            profiles
+          end
         end
 
-        private
-
-        def profile_node
-          @parsed_xml.at_xpath(".//Profile\
-                             [contains('#{test_result_node['id']}', @id)]")
+        def profile_nodes(xpath = ".//Profile")
+          xpath_nodes(xpath)
         end
       end
     end

--- a/lib/openscap_parser/profiles.rb
+++ b/lib/openscap_parser/profiles.rb
@@ -18,7 +18,7 @@ module OpenscapParser
         private
 
         def profile_node
-          @report_xml.at_xpath(".//Profile\
+          @parsed_xml.at_xpath(".//Profile\
                              [contains('#{test_result_node['id']}', @id)]")
         end
       end

--- a/lib/openscap_parser/rule.rb
+++ b/lib/openscap_parser/rule.rb
@@ -16,19 +16,22 @@ module OpenscapParser
     end
 
     def title
-      @title ||= @rule_xml.at_css('title').children.first.text
+      @title ||= @rule_xml.at_css('title') &&
+        @rule_xml.at_css('title').text
     end
 
     def description
-      rule_node ||= @rule_xml.at_css('description')
-      @description ||= newline_to_whitespace(rule_node.text) if rule_node && rule_node.text
+      @description ||= newline_to_whitespace(
+        @rule_xml.at_css('description') &&
+          @rule_xml.at_css('description').text || ''
+      )
     end
 
     def rationale
-      rationale_node ||= @rule_xml.at_css('rationale')
-      @rationale ||= newline_to_whitespace(rationale_node.children.text) if rationale_node &&
-        rationale_node.children &&
-        rationale_node.children.text
+      @rationale ||= newline_to_whitespace(
+        @rule_xml.at_css('rationale') &&
+          @rule_xml.at_css('rationale').text || ''
+      )
     end
 
     def references

--- a/lib/openscap_parser/rules.rb
+++ b/lib/openscap_parser/rules.rb
@@ -12,7 +12,7 @@ module OpenscapParser
         def rule_objects
           return @rule_objects unless @rule_objects.nil?
 
-          @rule_objects ||= @report_xml.search('Rule').map do |rule|
+          @rule_objects ||= @parsed_xml.search('Rule').map do |rule|
             Rule.new(rule_xml: rule)
           end
         end

--- a/lib/openscap_parser/rules.rb
+++ b/lib/openscap_parser/rules.rb
@@ -10,13 +10,15 @@ module OpenscapParser
         end
 
         def rule_objects
-          return @rule_objects unless @rule_objects.nil?
-
-          @rule_objects ||= @parsed_xml.search('Rule').map do |rule|
-            Rule.new(rule_xml: rule)
+          @rule_objects ||= rule_nodes.map do |rule_node|
+            Rule.new(rule_xml: rule_node)
           end
         end
         alias :rules :rule_objects
+
+        def rule_nodes(xpath = ".//Rule")
+          xpath_nodes(xpath)
+        end
       end
     end
   end

--- a/lib/openscap_parser/test_result.rb
+++ b/lib/openscap_parser/test_result.rb
@@ -7,7 +7,7 @@ module OpenscapParser
         private
 
         def test_result_node
-          @test_result_node ||= @report_xml.at_css('TestResult')
+          @test_result_node ||= @parsed_xml.at_css('TestResult')
         end
       end
     end

--- a/lib/openscap_parser/test_result.rb
+++ b/lib/openscap_parser/test_result.rb
@@ -4,10 +4,41 @@ module OpenscapParser
   module TestResult
     def self.included(base)
       base.class_eval do
-        private
+        def score
+          @score ||= test_result_node &&
+            test_result_node.search('score').text.to_f
+        end
+
+        def start_time
+          @start_time ||= test_result_node &&
+            DateTime.parse(test_result_node['start-time'])
+        end
+
+        def end_time
+          @end_time ||= test_result_node &&
+            DateTime.parse(test_result_node['end-time'])
+        end
+
+        def test_result_profiles
+          @test_result_profiles ||= test_result_profile_nodes.inject({}) do |profiles, profile_node|
+            profiles[profile_node['id']] = profile_node.at_css('title').text
+
+            profiles
+          end
+        end
 
         def test_result_node
-          @test_result_node ||= @parsed_xml.at_css('TestResult')
+          @test_result_node ||= xpath_node('.//TestResult')
+        end
+
+        def test_result_profile_id
+          test_result_node.xpath('./profile/@idref').text
+        end
+
+        private
+
+        def test_result_profile_nodes
+          profile_nodes(".//Profile [@id='#{test_result_profile_id}']")
         end
       end
     end

--- a/lib/openscap_parser/xml_file.rb
+++ b/lib/openscap_parser/xml_file.rb
@@ -11,5 +11,13 @@ module OpenscapParser
       @namespaces = @parsed_xml.namespaces.clone
       @parsed_xml.remove_namespaces!
     end
+
+    def xpath_node(xpath)
+      @parsed_xml.at_xpath(xpath)
+    end
+
+    def xpath_nodes(xpath)
+      @parsed_xml.xpath(xpath)
+    end
   end
 end

--- a/lib/openscap_parser/xml_file.rb
+++ b/lib/openscap_parser/xml_file.rb
@@ -5,11 +5,11 @@ module OpenscapParser
   module XmlFile
     attr_reader :namespaces
 
-    def report_xml(report_contents = '')
-      @report_xml ||= ::Nokogiri::XML.parse(
+    def parsed_xml(report_contents = '')
+      @parsed_xml ||= ::Nokogiri::XML.parse(
         report_contents, nil, nil, Nokogiri::XML::ParseOptions.new.norecover)
-      @namespaces = @report_xml.namespaces.clone
-      @report_xml.remove_namespaces!
+      @namespaces = @parsed_xml.namespaces.clone
+      @parsed_xml.remove_namespaces!
     end
   end
 end

--- a/lib/openscap_parser/xml_report.rb
+++ b/lib/openscap_parser/xml_report.rb
@@ -11,11 +11,11 @@ module OpenscapParser
         include OpenscapParser::XmlFile
 
         def host
-          @report_xml.search('target').text
+          @parsed_xml.search('target').text
         end
 
         def description
-          @report_xml.search('description').first.text
+          @parsed_xml.search('description').first.text
         end
       end
     end

--- a/test/openscap_parser/profiles_test.rb
+++ b/test/openscap_parser/profiles_test.rb
@@ -20,7 +20,7 @@ class ProfilesTest < Minitest::Test
         OpenStruct.new(id: ['xccdf_org.ssgproject.content_profile_standard'])
       end
 
-      report_xml(file_fixture('xccdf_report.xml').read)
+      parsed_xml(file_fixture('xccdf_report.xml').read)
 
       expected = {
         'xccdf_org.ssgproject.content_profile_standard' => \
@@ -35,7 +35,7 @@ class ProfilesTest < Minitest::Test
                             'ssgproject.content_profile_ospp42'])
       end
 
-      report_xml(file_fixture('rhel-xccdf-report.xml').read)
+      parsed_xml(file_fixture('rhel-xccdf-report.xml').read)
 
       expected = {
         'xccdf_org.ssgproject.content_profile_ospp42' => 'OSPP - Protection '\

--- a/test/openscap_parser/profiles_test.rb
+++ b/test/openscap_parser/profiles_test.rb
@@ -4,11 +4,14 @@ require 'test_helper'
 
 class ProfilesTest < Minitest::Test
   describe 'profiles are parsed from' do
-    include OpenscapParser::Profiles
-    include OpenscapParser::XMLReport
+    class TestParser
+      include OpenscapParser::Profiles
+      include OpenscapParser::XMLReport
+      include OpenscapParser::TestResult
 
-    def report_description
-      'description'
+      def report_description
+        'description'
+      end
     end
 
     def setup
@@ -16,32 +19,39 @@ class ProfilesTest < Minitest::Test
     end
 
     test 'standard fedora' do
-      def test_result_node
-        OpenStruct.new(id: ['xccdf_org.ssgproject.content_profile_standard'])
+      class TestParser
+        def test_result_profile_id
+          'xccdf_org.ssgproject.content_profile_standard'
+        end
       end
 
-      parsed_xml(file_fixture('xccdf_report.xml').read)
+      test_parser = TestParser.new
+
+      test_parser.parsed_xml(file_fixture('xccdf_report.xml').read)
 
       expected = {
         'xccdf_org.ssgproject.content_profile_standard' => \
         'Standard System Security Profile for Fedora'
       }
-      assert_equal expected, profiles
+      assert_equal expected, test_parser.test_result_profiles
     end
 
     test 'ospp42 rhel' do
-      def test_result_node
-        OpenStruct.new(id: ['xccdf_org.open-scap_testresult_xccdf_org.'\
-                            'ssgproject.content_profile_ospp42'])
+      class TestParser
+        def test_result_profile_id
+          'xccdf_org.ssgproject.content_profile_ospp42'
+        end
       end
 
-      parsed_xml(file_fixture('rhel-xccdf-report.xml').read)
+      test_parser = TestParser.new
+
+      test_parser.parsed_xml(file_fixture('rhel-xccdf-report.xml').read)
 
       expected = {
         'xccdf_org.ssgproject.content_profile_ospp42' => 'OSPP - Protection '\
         'Profile for General Purpose Operating Systems v. 4.2'
       }
-      assert_equal expected, profiles
+      assert_equal expected, test_parser.test_result_profiles
     end
   end
 end

--- a/test/openscap_parser/xml_file_test.rb
+++ b/test/openscap_parser/xml_file_test.rb
@@ -10,13 +10,13 @@ class XmlFileTest < Minitest::Test
     @valid_report = file_fixture('xccdf_report.xml').read
   end
 
-  test 'report_xml parses a valid XML report' do
-    assert_equal report_xml(@valid_report).class, Nokogiri::XML::Document
+  test 'parsed_xml parses a valid XML report' do
+    assert_equal parsed_xml(@valid_report).class, Nokogiri::XML::Document
   end
 
-  test 'report_xml handles an invalid XML report' do
+  test 'parsed_xml handles an invalid XML report' do
     assert_raises Nokogiri::XML::SyntaxError do
-      report_xml(@invalid_report)
+      parsed_xml(@invalid_report)
     end
   end
 end

--- a/test/openscap_parser/xml_report_test.rb
+++ b/test/openscap_parser/xml_report_test.rb
@@ -6,7 +6,7 @@ class XMLReportTest < Minitest::Test
   include OpenscapParser::XMLReport
 
   def setup
-    report_xml(file_fixture('xccdf_report.xml').read)
+    parsed_xml(file_fixture('xccdf_report.xml').read)
   end
 
   test 'report_description' do

--- a/test/openscap_parser_test.rb
+++ b/test/openscap_parser_test.rb
@@ -24,7 +24,7 @@ class OpenscapParserTest < Minitest::Test
         'Red Hat Corporate Profile for Certified Cloud Providers (RH CCP)'
       }
       @report_parser = ::OpenscapParser::Base.new(fake_report)
-      assert_equal 1, @report_parser.profiles.count
+      assert_equal 1, @report_parser.test_result_profiles.count
     end
   end
 


### PR DESCRIPTION
We initially wrote this openscap_parser in the context of parsing SCAP scan results. Now we want to use it for parsing datastreams without results. This PR is only a refactoring to generalize some of the code and move things around to be specific to results parsing or not. Behavior should not change!