### PR TITLE
RHICOMPL-346: Enable more complete datastream parsing

### DIFF
--- a/lib/openscap_parser.rb
+++ b/lib/openscap_parser.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'openscap_parser/profiles'
+require 'openscap_parser/profile'
 require 'openscap_parser/rule'
 require 'openscap_parser/rule_result'
 require 'openscap_parser/rule_results'

--- a/lib/openscap_parser.rb
+++ b/lib/openscap_parser.rb
@@ -7,7 +7,7 @@ require 'openscap_parser/rule_results'
 require 'openscap_parser/rules'
 require 'openscap_parser/version'
 require 'openscap_parser/xml_report'
-require 'openscap_parser/ds'
+require 'openscap_parser/datastream'
 
 require 'date'
 

--- a/lib/openscap_parser/datastream.rb
+++ b/lib/openscap_parser/datastream.rb
@@ -2,7 +2,7 @@
 require 'openscap_parser/xml_file'
 
 module OpenscapParser
-  class Ds
+  class Datastream
     include OpenscapParser::XmlFile
     include OpenscapParser::Rules
     include OpenscapParser::Profiles

--- a/lib/openscap_parser/ds.rb
+++ b/lib/openscap_parser/ds.rb
@@ -4,33 +4,17 @@ require 'openscap_parser/xml_file'
 module OpenscapParser
   class Ds
     include OpenscapParser::XmlFile
+    include OpenscapParser::Rules
+    include OpenscapParser::Profiles
 
     def initialize(report)
       parsed_xml report
-    end
-
-    def profiles
-      @profiles ||= profile_nodes
     end
 
     def valid?
       return true if @parsed_xml.root.name == 'data-stream-collection' && namespaces.keys.include?('xmlns:ds')
       return true if @parsed_xml.root.name == 'Tailoring' && namespaces.keys.include?('xmlns:xccdf')
       false
-    end
-
-    private
-
-    def profile_nodes
-      @parsed_xml.xpath(".//Profile").map do |node|
-        id_node = node.attribute('id')
-        id = id_node.value if id_node
-        title_node = node.at_xpath('./title')
-        title = title_node.text if title_node
-        desc_node = node.at_xpath('./description')
-        description = desc_node.text if desc_node
-        { :id => id, :title => title, :description => description }
-      end
     end
   end
 end

--- a/lib/openscap_parser/profiles.rb
+++ b/lib/openscap_parser/profiles.rb
@@ -7,10 +7,8 @@ module OpenscapParser
     def self.included(base)
       base.class_eval do
         def profiles
-          @profiles ||= profile_nodes.inject({}) do |profiles, profile_node|
-            profiles[profile_node['id']] = profile_node.at_css('title').text
-
-            profiles
+          @profiles ||= profile_nodes.map do |profile_node|
+            OpenscapParser::Profile.new(profile_xml: profile_node)
           end
         end
 

--- a/lib/openscap_parser/rule.rb
+++ b/lib/openscap_parser/rule.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'openscap_parser/rule_identifier'
+require 'openscap_parser/rule_reference'
+
 # Mimics openscap-ruby Rule interface
 module OpenscapParser
   class Rule
@@ -9,6 +12,10 @@ module OpenscapParser
 
     def id
       @id ||= @rule_xml['id']
+    end
+
+    def selected
+      @selected ||= @rule_xml['selected']
     end
 
     def severity
@@ -35,16 +42,21 @@ module OpenscapParser
     end
 
     def references
-      @references ||= @rule_xml.css('reference').map do |node|
-        { href: node['href'], label: node.text }
+      @references ||= reference_nodes.map do |node|
+        RuleReference.new(reference_xml: node)
       end
     end
 
+    def reference_nodes
+      @reference_nodes ||= @rule_xml.xpath('reference')
+    end
+
     def identifier
-      @identifier ||= {
-        label: @rule_xml.at_css('ident') && @rule_xml.at_css('ident').text,
-        system: (ident = @rule_xml.at_css('ident')) && ident['system']
-      }
+      @identifier ||= RuleIdentifier.new(identifier_xml: @identifier_node)
+    end
+
+    def identifier_node
+      @identifier_node ||= @rule_xml.at_xpath('ident')
     end
 
     private

--- a/lib/openscap_parser/rule_identifier.rb
+++ b/lib/openscap_parser/rule_identifier.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# RuleIdentifier interface as an object
+module OpenscapParser
+  class RuleIdentifier
+    def initialize(identifier_xml: nil)
+      @identifier_xml = identifier_xml
+    end
+
+    def label
+      @label ||= @identifier_xml && @identifier_xml.text
+    end
+
+    def system
+      @system ||= @identifier_xml && @identifier_xml['system']
+    end
+  end
+end

--- a/lib/openscap_parser/rule_reference.rb
+++ b/lib/openscap_parser/rule_reference.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# RuleReference interface as an object
+module OpenscapParser
+  class RuleReference
+    def initialize(reference_xml: nil)
+      @reference_xml = reference_xml
+    end
+
+    def href
+      @href ||= @reference_xml && @reference_xml['href']
+    end
+
+    def label
+      @label ||= @reference_xml && @reference_xml.text
+    end
+  end
+end

--- a/test/datastream_test.rb
+++ b/test/datastream_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'test_helper'
 
-class DsTest < MiniTest::Test
+class DatastreamTest < MiniTest::Test
   context 'scap content' do
     should 'be able to parse profiles' do
       parser = create_parser('ssg-rhel7-ds.xml')
@@ -59,6 +59,6 @@ class DsTest < MiniTest::Test
 
   def create_parser(file)
     scap_content = file_fixture(file).read
-    ::OpenscapParser::Ds.new(scap_content)
+    ::OpenscapParser::Datastream.new(scap_content)
   end
 end

--- a/test/ds_test.rb
+++ b/test/ds_test.rb
@@ -18,7 +18,7 @@ class DsTest < MiniTest::Test
         "Red Hat Corporate Profile for Certified Cloud Providers (RH CCP)",
         "PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 7"
       ]
-      assert_equal(profile_titles, parser.profiles.map { |profile| profile[:title] })
+      assert_equal(profile_titles, parser.profiles.map(&:title))
     end
   end
 
@@ -29,7 +29,7 @@ class DsTest < MiniTest::Test
         "Standard System Security Profile [CUSTOMIZED]",
         "Common Profile for General-Purpose Systems [CUSTOMIZED]"
       ]
-      assert_equal(profile_titles, parser.profiles.map { |profile| profile[:title] })
+      assert_equal(profile_titles, parser.profiles.map(&:title))
     end
   end
 


### PR DESCRIPTION
This allows datastreams as a first class citizen in the openscap_parser. We are no longer bound by parsing only reports. Shared resources such as `Rule`s or `Profile`s are separated into their own modules and shared between the different file types.

https://projects.engineering.redhat.com/browse/RHICOMPL-346

Signed-off-by: Andrew Kofink <akofink@redhat.com>