### PR TITLE
Add rake tasks when included with rails

### DIFF
--- a/lib/openscap_parser.rb
+++ b/lib/openscap_parser.rb
@@ -10,6 +10,7 @@ require 'openscap_parser/xml_report'
 require 'openscap_parser/datastream'
 
 require 'date'
+require 'railtie' if defined?(Rails)
 
 module OpenscapParser
   class Error < StandardError; end

--- a/lib/railtie.rb
+++ b/lib/railtie.rb
@@ -1,0 +1,15 @@
+# lib/railtie.rb
+require 'openscap_parser'
+
+if defined?(Rails)
+  module OpenscapParser
+    class Railtie < Rails::Railtie
+      railtie_name :openscap_parser
+
+      rake_tasks do
+        path = File.expand_path(__dir__)
+        Dir.glob("#{path}/tasks/**/*.rake").each { |f| load f }
+      end
+    end
+  end
+end


### PR DESCRIPTION
When installed as a gem alongside Rails, the rake tasks provided by this gem will be added to the Rails environment rake tasks via railtie.

Signed-off-by: Andrew Kofink <akofink@redhat.com>