### PR TITLE
fix: RHICOMPL-3900 disable required ruby version rubocop check

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -115,3 +115,6 @@ Style/RedundantAssignment:
 
 Style/RedundantRegexpEscape:
   Enabled: false
+
+Gemspec/RequiredRubyVersion:
+  Enabled: false

--- a/openscap_parser.gemspec
+++ b/openscap_parser.gemspec
@@ -37,7 +37,6 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 3.1'
 
   spec.add_dependency 'nokogiri', '~> 1.6'
   spec.add_development_dependency 'bundler'


### PR DESCRIPTION
Disabling the Gemspec/RequiredRubyVersion because we don't want to limit the supported ruby version because of static analysis. 