### PR TITLE
chore: stating required Ruby version

### DIFF
--- a/openscap_parser.gemspec
+++ b/openscap_parser.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
+  spec.required_ruby_version = '>= 1.9.2'
 
   spec.add_dependency 'nokogiri', '~> 1.6'
   spec.add_development_dependency 'bundler'


### PR DESCRIPTION
Responding to https://github.com/OpenSCAP/openscap_parser/pull/56#issuecomment-1759457101.

Using required ruby version based on gem's dependency requirements (nokogiri 1.6).